### PR TITLE
add Sidekick under Debugging section

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@
 
 - [Flask-DebugToolbar](https://flask-debugtoolbar.readthedocs.io) - Port of Django's debug toolbar for Flask.
 - [Flask-Profiler](https://github.com/muatik/flask-profiler) - Endpoint analyzer/profiler.
+- [Sidekick Python Agent](https://github.com/runsidekick/sidekick-agent-python) - Sidekick Live App. Debugger Python agent
 
 #### Fixtures
 


### PR DESCRIPTION
Hi,

Sidekick has become very popular after going open-source. Python agent is also open-source and allows you to put logs & tracepoints to your running applications. Would you mind adding it ?