### PR TITLE
Remove Flask-VueJS because has been archived

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,10 @@ Compute:
 
 ## Projects
 
+### Architecture
+
+- [MVC Flask](https://github.com/marcuxyz/mvc-flask) - You can use the mvc pattern in your flask application using this extension.
+
 ### Boilerplates
 
 - [cookiecutter-flask](https://github.com/cookiecutter-flask/cookiecutter-flask) - With Bootstrap 4, asset bundling annd minification with webpack, starter templates, and registration/authentication.

--- a/README.md
+++ b/README.md
@@ -341,7 +341,6 @@ Compute:
 - [uwsgi-nginx-flask-docker](https://github.com/tiangolo/uwsgi-nginx-flask-docker) - Docker image with uWSGI and Nginx for Flask applications in Python running in a single container.
 - [React-Redux-Flask](https://github.com/dternyak/React-Redux-Flask) - Boilerplate application for a Flask JWT Backend and a React/Redux Front-End with Material UI.
 - [Flask-Scaffold](https://github.com/Leo-G/Flask-Scaffold) - Prototype Database driven Web apps in Angular 6, Bootstrap 4 and REST API's with Flask.
-- [Flask-VueJS](https://github.com/marcuxyz/flask-vuejs) - Connect Flask application with VueJS.
 
 ### Open Source Projects
 


### PR DESCRIPTION
The  Flask-VueJS extension has been archived and was removed from the list