### PR TITLE
Add Flask-PraisonAI to Utils section

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@
 - [Flask-Limiter](https://flask-limiter.readthedocs.io) - Rate limiting features to Flask routes.
 - [Flask-Moment](https://github.com/miguelgrinberg/Flask-Moment) - Moment.js date and time formatting helpers for Jinja2 templates.
 - [Flask-Paginate](https://pythonhosted.org/Flask-paginate/) - Pagination support.
+- [Flask-PraisonAI](https://github.com/MervinPraison/flask-praisonai) - Blueprint for integrating PraisonAI multi-agent workflows.
 - [Flask-Reactize](https://github.com/Azure-Samples/flask-reactize) - Hides the Node.js development backend for React behind a Flask application.
 - [Flask-Shell2HTTP](https://github.com/Eshaan7/Flask-Shell2HTTP) - RESTful/HTTP wrapper for Python's subprocess API, so you can convert any command-line tool into a RESTful API service.
 - [Flask-Sitemap](https://flask-sitemap.readthedocs.io) - Sitemap generation.


### PR DESCRIPTION
Adds [Flask-PraisonAI](https://github.com/MervinPraison/flask-praisonai) to the Utils section.

**What it does:**
- Provides a Flask blueprint for integrating with PraisonAI multi-agent workflows
- Includes sync client for API calls
- Published on PyPI: https://pypi.org/project/flask-praisonai/

**Placement:** Utils section, alphabetically ordered between Flask-Paginate and Flask-Reactize.