### PR TITLE
Add SnapDeploy to PaaS hosting section

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@
 - [Microsoft Azure App Service](https://azure.microsoft.com/en-us/products/app-service/)
 - [Divio](https://www.divio.com)
 - [Render](https://render.com/)
+- [SnapDeploy](https://snapdeploy.dev) - Docker container hosting with 1-click Flask template and free tier. Auto-detects Flask, configures gunicorn on port 5000.
 
 ### IaaS
 


### PR DESCRIPTION
Adding SnapDeploy as a PaaS option for Flask deployment.

SnapDeploy has a 1-click Flask template and auto-detects Flask apps
from requirements.txt. Configures gunicorn with the correct port (5000)
and deploys as a Docker container.

- Free tier: up to 4 containers, no credit card
- 1-click Flask template: https://snapdeploy.dev/deploy-flask-app
- GitHub auto-deploy on push
- Flask deployment guide: https://snapdeploy.dev/blog/deploy-flask-app-free-2026

GitHub Marketplace: https://github.com/marketplace/snapdeploy-app