### PR TITLE
Add Flask SaaS Starter — boilerplate with auth, billing, and systemd

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@
   - [Serverless](#serverless)
 - [Projects](#projects)
   - [Boilerplates](#boilerplates)
+- [Flask SaaS Starter](https://github.com/clementslowik/flask-saas-starter) - Ready-to-deploy boilerplate with auth, API keys, rate limiting, Stripe billing, SQLite WAL, systemd deploy.
   - [Open Source Projects](#open-source-projects)
 
 ## Third-Party Extensions


### PR DESCRIPTION
[Flask SaaS Starter](https://github.com/clementslowik/flask-saas-starter) is a single-file Flask boilerplate (~200 lines) with user auth, API keys, rate limiting, Stripe checkout, SQLite WAL, and systemd deploy. MIT licensed.