### PR TITLE
Add AI Resume Screener and FakeShield AI to Open Source Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,9 @@ Compute:
 - [sr.ht](https://git.sr.ht/~sircmpwn/core.sr.ht/tree) - Git hosting service (check out [Why I chose Flask to build sr.ht's mini-services](https://drewdevault.com/2019/01/30/Why-I-built-sr.ht-with-Flask.html) as well).
 - [Timesketch](https://github.com/google/timesketch) - Collaborative forensic timeline analysis.
 
+- [AI Resume Screener](https://github.com/aasimansari1/Resume-Screening) - NLP-powered candidate ranking web app built with Flask, spaCy, and scikit-learn. Parses PDF/DOCX resumes, scores candidates via TF-IDF + skills matching, generates interview questions, and exports ranked CSV/PDF reports.
+- [FakeShield AI](https://github.com/aasimansari1/fake-news-detector) - Fake news detection web app using Flask, NLTK, and scikit-learn. Benchmarks 4 ML models, auto-selects the best, and returns confidence scores with explainable word-level evidence.
+
 ---
 
 <br>


### PR DESCRIPTION
Two open-source Flask projects worth adding to the list:

**[AI Resume Screener](https://github.com/aasimansari1/Resume-Screening)**
An NLP-powered resume screening and candidate ranking platform. Parses PDF/DOCX resumes, scores candidates using TF-IDF cosine similarity + skills gap analysis (336-skill database), generates AI interview questions, and exports ranked CSV/PDF reports. Built with Flask, spaCy, scikit-learn, and Chart.js.

**[FakeShield AI](https://github.com/aasimansari1/fake-news-detector)**
Fake news detection web app with a full NLP preprocessing pipeline and 4-model comparison (Passive Aggressive ~91%, Naive Bayes, Logistic Regression, Random Forest). Returns per-prediction confidence score and key word influence direction. Includes a REST `/predict` endpoint.

Both are MIT licensed with full documentation and deploy-to-Render buttons.