### PR TITLE
Add two production Flask apps: Saju Fortune + GeoInfomatic

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,9 @@ Compute:
 
 ## Projects
 
+
+- [Saju Fortune](https://tarofortune.pythonanywhere.com) - Free Korean four-pillars (saju) astrology calculator with EN+KR interpretations. 60 day-pillar archetypes, five elements, ten gods, twelve life stages, daily luck, compatibility. Flask + Pillow for dynamic OG cards, no DB, deployed on PythonAnywhere free tier.
+- [GeoInfomatic — Living Zone Accessibility](https://geoinfomatic.pythonanywhere.com) - Isochrone-based neighborhood accessibility analyzer for Korea. Walk or transit, 10-45 min radius, 8 facility types, AI summary, 100-point composite score. Flask + Leaflet + OSRM walking graph + custom transit graph.
 ### Boilerplates
 
 - [cookiecutter-flask](https://github.com/cookiecutter-flask/cookiecutter-flask) - With Bootstrap 4, asset bundling annd minification with webpack, starter templates, and registration/authentication.


### PR DESCRIPTION
Adds two real-world Flask applications running on the PythonAnywhere free tier.

1. **Saju Fortune** — https://tarofortune.pythonanywhere.com
   Korean four-pillars astrology calculator (EN+KR). Uses Meeus astronomical algorithms for solar-term boundary calculations. Dynamic OG card generation with Pillow. No database — pure computation.

2. **GeoInfomatic — Living Zone Accessibility** — https://geoinfomatic.pythonanywhere.com
   Isochrone-based neighborhood analyzer. Walking/transit isochrones drawn with Leaflet polygons. Custom Korean subway+bus graph traversal with transfer penalties. Freemium model.

Both are solo-built and demonstrate what's possible on Flask + PA's free tier. Happy to revise placement.
