### PR TITLE
Add flask-unirate to Utils section

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@
 - [Flask-Sitemap](https://flask-sitemap.readthedocs.io) - Sitemap generation.
 - [Flask-SocketIO](https://flask-socketio.readthedocs.io) - Socket.IO integration.
 - [Flask-SSE](https://flask-sse.readthedocs.io) - Streaming with flask.
+- [flask-unirate](https://github.com/UniRate-API/flask-unirate) - Currency exchange rates with Jinja filters (`unirate_convert`, `unirate_format`) and optional Flask-Caching integration.
 
 ## Resources
 


### PR DESCRIPTION
Adds [flask-unirate](https://github.com/UniRate-API/flask-unirate) to the Utils section.

**What it is:** A Flask extension providing currency exchange rate lookups via the UniRate API, with Jinja template filters (`unirate_convert`, `unirate_format`, `unirate_rate`) and optional Flask-Caching integration for rate data. Published on [PyPI](https://pypi.org/project/flask-unirate/) with mock tests and CI coverage.

**Disclosure:** I maintain flask-unirate and the UniRate API it connects to.
